### PR TITLE
Display progress bar on the website

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -21,69 +21,69 @@ const ProgressBar = ({
   disabled,
   className,
 }: ProgressBarType) => {
-
   const clampedValue = Math.min(maxValue, Math.max(currentValue, minValue));
-  const widthPercentage = ((clampedValue - minValue) / (maxValue - minValue)) * 100;
+  const widthPercentage =
+    ((clampedValue - minValue) / (maxValue - minValue)) * 100;
 
   return (
     <div
       className={classNames(
-        "w-72 md:w-full max-w-md border-black border-2 focus:outline-none h-9 overflow-hidden shadow-[2px_2px_0px_rgba(0,0,0,1)]",
+        "w-72 md:w-full max-w-md border-black border-2 focus:outline-none h-9 overflow-hidden shadow-[2px_2px_0px_rgba(0,0,0,1)] bg-white",
         { "rounded-none": rounded === "none" },
         { "rounded-md": rounded === "md" },
         { "rounded-full": rounded === "full" },
-        { "shadow-[2px_2px_0px_rgba(0,0,0,1)]": !disabled},
+        { "shadow-[2px_2px_0px_rgba(0,0,0,1)]": !disabled },
         {
-            "border-[#727272] bg-[#D4D4D4] text-[#676767] hover:bg-[#D4D4D4] hover:shadow-none active:bg-[#D4D4D4]":
-              disabled,
+          "border-[#727272] bg-[#D4D4D4] text-[#676767] hover:bg-[#D4D4D4] hover:shadow-none active:bg-[#D4D4D4]":
+            disabled,
         },
         className
       )}
     >
       <div
-        style={{width: widthPercentage + '%'}}
+        style={{ width: widthPercentage + "%" }}
         className={classNames(
-            "h-full flex flex-row items-center justify-end overflow-hidden",
-            {
-              "bg-violet-200 hover:bg-violet-300":
-                color === "violet" && !disabled,
-            },
-            {
-              "bg-pink-200 hover:bg-pink-300":
-                color === "pink" && !disabled,
-            },
-            {
-              "bg-red-200 hover:bg-red-300":
-                color === "red" && !disabled,
-            },
-            {
-              "bg-orange-200 hover:bg-orange-300":
-                color === "orange" && !disabled,
-            },
-            {
-              "bg-yellow-200 hover:bg-yellow-300":
-                color === "yellow" && !disabled,
-            },
-            {
-              "bg-lime-200 hover:bg-lime-300":
-                color === "lime" && !disabled,
-            },
-            {
-              "bg-cyan-200 hover:bg-cyan-300":
-                color === "cyan" && !disabled,
-            },
-            { "rounded-none": rounded === "none" },
-            { "rounded-md": rounded === "md" },
-            { "rounded-full": rounded === "full" },
+          "h-full flex flex-row items-center justify-end overflow-hidden",
+          {
+            "bg-violet-200 hover:bg-violet-300":
+              color === "violet" && !disabled,
+          },
+          {
+            "bg-pink-200 hover:bg-pink-300": color === "pink" && !disabled,
+          },
+          {
+            "bg-red-200 hover:bg-red-300": color === "red" && !disabled,
+          },
+          {
+            "bg-orange-200 hover:bg-orange-300":
+              color === "orange" && !disabled,
+          },
+          {
+            "bg-yellow-200 hover:bg-yellow-300":
+              color === "yellow" && !disabled,
+          },
+          {
+            "bg-lime-200 hover:bg-lime-300": color === "lime" && !disabled,
+          },
+          {
+            "bg-cyan-200 hover:bg-cyan-300": color === "cyan" && !disabled,
+          },
+          { "rounded-none": rounded === "none" },
+          { "rounded-md": rounded === "md" },
+          { "rounded-full": rounded === "full" }
         )}
-        >
+      >
         {showPercentage && !disabled && (
-            <h1 className={classNames(
-                `mr-2 ${widthPercentage != 100 ? "font-bold" : "font-black"} opacity-60`,
-                className
-            )}>
-                {Math.round(widthPercentage)}% 
-            </h1>
+          <h1
+            className={classNames(
+              `mr-2 ${
+                widthPercentage != 100 ? "font-bold" : "font-black"
+              } opacity-60`,
+              className
+            )}
+          >
+            {Math.round(widthPercentage)}%
+          </h1>
         )}
       </div>
     </div>

--- a/src/data/componentsData.tsx
+++ b/src/data/componentsData.tsx
@@ -9,6 +9,7 @@ import DropDown from "../components/DropDown";
 import IconButton from "../components/IconButton";
 import Input from "../components/Input";
 import ToggleSwitch from "../components/ToggleSwitch";
+import ProgressBar from "../components/ProgressBar";
 import IconButtonMarkup from "./iconButtonMarkup";
 import buttonMarkup from "./buttonMarkup";
 import cardMarkup from "./cardMarkup";
@@ -17,6 +18,7 @@ import dialogMarkup from "./dialogMarkup";
 import dropdownMarkup from "./dropdownMarkup";
 import inputMarkup from "./inputMarkup";
 import toggleSwitchMarkup from "./toggleSwitchMarkup";
+import progressBarMarkup from "./progressBarMarkup";
 import SampleImage from "../assets/neo-brutalism-image1.jpg";
 
 export type componentsDataType = {
@@ -136,6 +138,12 @@ const componentsData: componentsDataType = [
     path: "toggleSwitch",
     component: <ToggleSwitch text="Toggle me" />,
     markup: toggleSwitchMarkup,
+  },
+  {
+    name: "ProgressBar",
+    path: "progressBar",
+    component: <ProgressBar currentValue={70} rounded="full" color="lime" />,
+    markup: progressBarMarkup,
     new: true,
   },
 ];

--- a/src/data/progressBarMarkup.tsx
+++ b/src/data/progressBarMarkup.tsx
@@ -1,0 +1,16 @@
+const checkboxMarkup = (): string => {
+  return `
+     <div
+        class="w-72 md:w-full max-w-md border-black border-2 focus:outline-none h-9 overflow-hidden shadow-[2px_2px_0px_rgba(0,0,0,1)] bg-white rounded-full"
+      >
+        <div
+          class="w-[70%] h-full flex flex-row items-center justify-end overflow-hidden bg-lime-200 hover:bg-lime-300 rounded-full"
+        >
+          <h1 class="mr-2 font-bold opacity-60">70%</h1>
+        </div>
+      </div>
+
+  `;
+};
+
+export default checkboxMarkup;

--- a/src/pages/Component.tsx
+++ b/src/pages/Component.tsx
@@ -69,7 +69,9 @@ const Component = () => {
       {displayingComponent && (
         <>
           <div className="flex justify-center items-center border-black border-2 rounded mb-12 py-10 bg-violet-100 min-h-[360px]">
-            <div>{displayingComponent?.component}</div>
+            <div className="flex justify-center items-center w-[100%]">
+              {displayingComponent?.component}
+            </div>
           </div>
           <div className="flex justify-end items-center mb-3 space-x-4">
             <div className="block cursor-pointer">


### PR DESCRIPTION
- Display the progress bar that @Jarvx200 created on the web page so that users can access the component via the website as well
  - https://github.com/marieooq/neo-brutalism-ui-library/pull/10
- The link is going to be `components/progressBar`
- Add a link to the sidebar
- Display the component and the sample code to copy  on the right side of the Progress bar component page

<img width="1465" alt="Screenshot 2024-06-15 at 12 37 20 PM" src="https://github.com/marieooq/neo-brutalism-ui-library/assets/33252783/26a8754d-5598-4a97-80bc-d6cbbe192006">
