### PR TITLE
Add children prop to button

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames"
 
-type ButtonType = {
+type ButtonPropsBase = {
   buttonText?: string
   rounded?: "none" | "md" | "full"
   size?: "sm" | "md" | "lg"
@@ -9,6 +9,18 @@ type ButtonType = {
   className?: string
   children?: React.ReactNode
 }
+
+type ButtonTextProps = ButtonPropsBase & {
+  buttonText: string
+  children?: never
+}
+
+type ButtonChildrenProps = ButtonPropsBase & {
+  children: React.ReactNode
+  buttonText?: never
+}
+
+type ButtonType = ButtonTextProps | ButtonChildrenProps
 
 const Button = ({
   buttonText = "Enabled",
@@ -19,6 +31,8 @@ const Button = ({
   className,
   children,
 }: ButtonType) => {
+  const buttonLabel = children || buttonText
+
   return (
     <button
       className={classNames(
@@ -66,7 +80,7 @@ const Button = ({
       )}
       disabled={disabled}
     >
-      {!children ? buttonText : children}
+      {buttonLabel}
     </button>
   )
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,13 +1,14 @@
-import classNames from "classnames";
+import classNames from "classnames"
 
 type ButtonType = {
-  buttonText: string;
-  rounded?: "none" | "md" | "full";
-  size?: "sm" | "md" | "lg";
-  color?: "violet" | "pink" | "red" | "orange" | "yellow" | "lime" | "cyan";
-  disabled?: boolean;
-  className?: string;
-};
+  buttonText?: string
+  rounded?: "none" | "md" | "full"
+  size?: "sm" | "md" | "lg"
+  color?: "violet" | "pink" | "red" | "orange" | "yellow" | "lime" | "cyan"
+  disabled?: boolean
+  className?: string
+  children?: React.ReactNode
+}
 
 const Button = ({
   buttonText = "Enabled",
@@ -16,6 +17,7 @@ const Button = ({
   color = "cyan",
   disabled,
   className,
+  children,
 }: ButtonType) => {
   return (
     <button
@@ -64,9 +66,9 @@ const Button = ({
       )}
       disabled={disabled}
     >
-      {buttonText}
+      {!children ? buttonText : children}
     </button>
-  );
-};
+  )
+}
 
-export default Button;
+export default Button

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -76,9 +76,9 @@ const ProgressBar = ({
         {showPercentage && !disabled && (
           <h1
             className={classNames(
-              `mr-2 ${
-                widthPercentage != 100 ? "font-bold" : "font-black"
-              } opacity-60`,
+              "mr-2",
+              widthPercentage !== 100 ? "font-bold" : "font-black",
+              widthPercentage !== 100 ? "opacity-60" : "opacity-100",
               className
             )}
           >

--- a/src/data/progressBarMarkup.tsx
+++ b/src/data/progressBarMarkup.tsx
@@ -1,16 +1,86 @@
-const checkboxMarkup = (): string => {
+const progressBarMarkup = (): string => {
   return `
-     <div
-        class="w-72 md:w-full max-w-md border-black border-2 focus:outline-none h-9 overflow-hidden shadow-[2px_2px_0px_rgba(0,0,0,1)] bg-white rounded-full"
-      >
-        <div
-          class="w-[70%] h-full flex flex-row items-center justify-end overflow-hidden bg-lime-200 hover:bg-lime-300 rounded-full"
-        >
-          <h1 class="mr-2 font-bold opacity-60">70%</h1>
-        </div>
-      </div>
+   const ProgressBar = ({
+  minValue = 0,
+  maxValue = 100,
+  rounded = "none",
+  color = "cyan",
+  currentValue = 0,
+  showPercentage = true,
+  disabled,
+  className,
+}: ProgressBarType) => {
+  const clampedValue = Math.min(maxValue, Math.max(currentValue, minValue));
+  const widthPercentage =
+    ((clampedValue - minValue) / (maxValue - minValue)) * 100;
 
+  return (
+    <div
+      className={classNames(
+        "w-72 md:w-full max-w-md border-black border-2 focus:outline-none h-9 overflow-hidden shadow-[2px_2px_0px_rgba(0,0,0,1)] bg-white",
+        { "rounded-none": rounded === "none" },
+        { "rounded-md": rounded === "md" },
+        { "rounded-full": rounded === "full" },
+        { "shadow-[2px_2px_0px_rgba(0,0,0,1)]": !disabled },
+        {
+          "border-[#727272] bg-[#D4D4D4] text-[#676767] hover:bg-[#D4D4D4] hover:shadow-none active:bg-[#D4D4D4]":
+            disabled,
+        },
+        className
+      )}
+    >
+      <div
+        style={{ width: widthPercentage + "%" }}
+        className={classNames(
+          "h-full flex flex-row items-center justify-end overflow-hidden",
+          {
+            "bg-violet-200 hover:bg-violet-300":
+              color === "violet" && !disabled,
+          },
+          {
+            "bg-pink-200 hover:bg-pink-300": color === "pink" && !disabled,
+          },
+          {
+            "bg-red-200 hover:bg-red-300": color === "red" && !disabled,
+          },
+          {
+            "bg-orange-200 hover:bg-orange-300":
+              color === "orange" && !disabled,
+          },
+          {
+            "bg-yellow-200 hover:bg-yellow-300":
+              color === "yellow" && !disabled,
+          },
+          {
+            "bg-lime-200 hover:bg-lime-300": color === "lime" && !disabled,
+          },
+          {
+            "bg-cyan-200 hover:bg-cyan-300": color === "cyan" && !disabled,
+          },
+          { "rounded-none": rounded === "none" },
+          { "rounded-md": rounded === "md" },
+          { "rounded-full": rounded === "full" }
+        )}
+      >
+        {showPercentage && !disabled && (
+          <h1
+            className={classNames(
+              "mr-2",
+              widthPercentage !== 100 ? "font-bold" : "font-black",
+                     widthPercentage !== 100 ? "opacity-60" : "opacity-100",
+              className
+            )}
+          >
+            {Math.round(widthPercentage)}%
+          </h1>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProgressBar;
   `;
 };
 
-export default checkboxMarkup;
+export default progressBarMarkup;

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -1,6 +1,7 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import React from "react"
+import type { Meta, StoryObj } from "@storybook/react"
 
-import Button from "../components/Button";
+import Button from "../components/Button"
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
 const meta = {
@@ -10,105 +11,111 @@ const meta = {
   // argTypes: {
   //   button: { control: "color" },
   // },
-} satisfies Meta<typeof Button>;
+} satisfies Meta<typeof Button>
 
-export default meta;
-type Story = StoryObj<typeof meta>;
+export default meta
+type Story = StoryObj<typeof meta>
 
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Primary: Story = {
   args: {
     buttonText: "button",
   },
-};
+}
 
 export const Rounded: Story = {
   args: {
     ...Primary.args,
     rounded: "md",
   },
-};
+}
 
 export const FullRounded: Story = {
   args: {
     ...Primary.args,
     rounded: "full",
   },
-};
+}
 
 export const Small: Story = {
   args: {
     ...Primary.args,
     size: "sm",
   },
-};
+}
 
 export const Medium: Story = {
   args: {
     ...Primary.args,
     size: "md",
   },
-};
+}
 
 export const Large: Story = {
   args: {
     ...Primary.args,
     size: "lg",
   },
-};
+}
 
 export const Disabled: Story = {
   args: {
     ...Primary.args,
     disabled: true,
   },
-};
+}
 
 export const Violet: Story = {
   args: {
     ...Primary.args,
     color: "violet",
   },
-};
+}
 
 export const Pink: Story = {
   args: {
     ...Primary.args,
     color: "pink",
   },
-};
+}
 
 export const Red: Story = {
   args: {
     ...Primary.args,
     color: "red",
   },
-};
+}
 
 export const Orange: Story = {
   args: {
     ...Primary.args,
     color: "orange",
   },
-};
+}
 
 export const Yellow: Story = {
   args: {
     ...Primary.args,
     color: "yellow",
   },
-};
+}
 
 export const Lime: Story = {
   args: {
     ...Primary.args,
     color: "lime",
   },
-};
+}
 
 export const Cyan: Story = {
   args: {
     ...Primary.args,
     color: "cyan",
   },
-};
+}
+
+export const Children: Story = {
+  args: {
+    children: React.createElement("p", null, "button"),
+  },
+}

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -116,6 +116,6 @@ export const Cyan: Story = {
 
 export const Children: Story = {
   args: {
-    children: React.createElement("p", null, "button"),
+    children: React.createElement("p", null, "buttons"),
   },
 }


### PR DESCRIPTION
Per the conversation [in this issue](https://github.com/marieooq/neo-brutalism-ui-library/issues/14#issue-2401037881), I added a `children` prop to the button component. 
- the `children` prop accepts any `React.ReactNode` element
- If the `buttonText` and `children` props are used at the same time, the `buttonText` prop will be overridden
- Added types so that a Typescript flag alerts the user both props cannot be used at the same time